### PR TITLE
Fixed warnings under later jruby caused by importing jgit's config into global scope

### DIFF
--- a/lib/config.rb
+++ b/lib/config.rb
@@ -1,7 +1,5 @@
 module RJGit
 
-  import 'org.eclipse.jgit.lib.Config'
-  
   class Configuration
     
     attr_reader :jconfig, :path


### PR DESCRIPTION
Removed jgit.Config import. Generates warning about using RbConfig instead of Config. Full path was used anyway.
