### PR TITLE
Add support for commit.stats on first commit

### DIFF
--- a/lib/commit.rb
+++ b/lib/commit.rb
@@ -45,7 +45,8 @@ module RJGit
       df = DiffFormatter.new(DisabledOutputStream::INSTANCE)
       df.set_repository(@jrepo)
       df.set_context(0)
-      entries = df.scan(@jcommit.get_parents[0], @jcommit)
+      parent_commit = @jcommit.parent_count > 0 ? @jcommit.get_parents[0]:nil
+      entries = df.scan(parent_commit, @jcommit)
       results = {}
       total_del = 0
       total_ins = 0

--- a/spec/commit_spec.rb
+++ b/spec/commit_spec.rb
@@ -81,6 +81,13 @@ describe Commit do
       stats[2]["postpatriarchialist.txt"].should == [2, 0, 2] 
     end
 
+    it "should have stats on first commit" do
+      stats = Repo.new(TEST_REPO_PATH).commits[-1].stats
+      stats[0].should == 228
+      stats[1].should == 0
+      stats[2]["postpatriarchialist.txt"].should == [75, 0, 75]
+    end
+
     describe ".find_all(repo, ref, options)" do
       it "should return an empty array if nothing is found" do
         @commits = Commit.find_all(@bare_repo, 'remote42', {:limit => 10 })


### PR DESCRIPTION
Getting commit.stats on first commit resulted in Array Index Out of Bound on jcommit.get_parents[0] as first commit has no Parent.