### PR TITLE
New Porcelain.ls_tree implementation (fixes #15)

### DIFF
--- a/lib/blob.rb
+++ b/lib/blob.rb
@@ -6,6 +6,8 @@ module RJGit
   class Blob 
     
     attr_reader :id, :mode, :name, :path, :jblob
+    alias_method :get_name, :id
+    
     RJGit.delegate_to(RevBlob, :@jblob)
 
     def initialize(repository, mode, path, jblob)

--- a/lib/commit.rb
+++ b/lib/commit.rb
@@ -18,6 +18,8 @@ module RJGit
     attr_reader :jcommit
     attr_reader :parent_count
   
+    alias_method :get_name, :id
+    
     RJGit.delegate_to(RevCommit, :@jcommit)
     
     def initialize(repository, commit)

--- a/lib/rjgit.rb
+++ b/lib/rjgit.rb
@@ -65,37 +65,6 @@ module RJGit
       return bytes.to_a.pack('c*').force_encoding('UTF-8')
     end
     
-    # def self.ls_tree(repository, tree=nil, options={})
-    #   options = {:recursive => false, :print => false, :io => $stdout, :ref => Constants::HEAD}.merge options
-    #   jrepo = RJGit.repository_type(repository)
-    #   return nil unless jrepo
-    #   if tree 
-    #     jtree = RJGit.tree_type(tree)
-    #   else
-    #     last_commit_hash = jrepo.resolve(options[:ref])
-    #     return nil unless last_commit_hash
-    #     walk = RevWalk.new(jrepo)
-    #     jcommit = walk.parse_commit(last_commit_hash)
-    #     jtree = jcommit.get_tree
-    #   end
-    #   treewalk = TreeWalk.new(jrepo)
-    #   treewalk.set_recursive(options[:recursive])
-    #   treewalk.set_filter(PathFilter.create(options[:file_path])) if options[:file_path]
-    #   treewalk.add_tree(jtree)
-    #   entries = []
-    #   while treewalk.next
-    #     entry = {}
-    #     mode = treewalk.get_file_mode(0)
-    #     entry[:mode] = mode.get_bits
-    #     entry[:type] = Constants.type_string(mode.get_object_type)
-    #     entry[:id]   = treewalk.get_object_id(0).name
-    #     entry[:path] = treewalk.get_path_string
-    #     entries << entry
-    #   end
-    #   options[:io].puts RJGit.stringify(entries) if options[:print]
-    #   return entries
-    # end
-    
     def self.ls_tree(repository, path=nil, ref=Constants::HEAD, options={})
       options = {recursive: false, print: false, io: $stdout, path_filter: nil, ref: Constants::HEAD}.merge options
       jrepo = RJGit.repository_type(repository)
@@ -110,7 +79,6 @@ module RJGit
       if path
         treewalk = TreeWalk.forPath(jrepo, path, jtree)
         treewalk.enter_subtree
-        $stderr.puts "Must not ignore first entry! #{treewalk.get_path_string}"
       else
         treewalk = TreeWalk.new(jrepo)
         treewalk.add_tree(jtree)
@@ -236,7 +204,6 @@ module RJGit
         untouched_objects = {}
         formatter = TreeFormatter.new
         treemap ||= self.treemap
-        $stderr.puts "in build_tree, happily building a tree"
         if start_tree
           treewalk = TreeWalk.new(@jrepo)
           treewalk.add_tree(start_tree)
@@ -258,7 +225,6 @@ module RJGit
         end
         
         sorted_treemap = treemap.inject({}) {|h, (k,v)| v.is_a?(Hash) ? h["#{k}/"] = v : h[k] = v; h }.merge(untouched_objects).sort
-        $stderr.puts "we have a sorted_treemap: #{sorted_treemap.inspect}"
         sorted_treemap.each do |object_name, data|
           case data
             when Array
@@ -275,7 +241,6 @@ module RJGit
               @log[:added] << [:blob, object_name, blobid]
             end
         end
-        $stderr.puts "trying to insert object with object_inserter"
         object_inserter.insert(formatter)
       end
       

--- a/lib/rjgit.rb
+++ b/lib/rjgit.rb
@@ -71,11 +71,16 @@ module RJGit
       obj = jrepo.resolve(ref)
       walk = RevWalk.new(jrepo)
       begin
-        jcommit = walk.parse_commit(obj)
+        revobj = walk.parse_any(obj)
+        jtree = case revobj.get_type
+        when Constants::OBJ_TREE
+          walk.parse_tree(obj)
+        when Constants::OBJ_COMMIT
+          walk.parse_commit(obj).get_tree
+        end
       rescue Java::OrgEclipseJgitErrors::MissingObjectException, Java::JavaLang::IllegalArgumentException, Java::JavaLang::NullPointerException
         return nil
       end
-      jtree = jcommit.get_tree
       if path
         treewalk = TreeWalk.forPath(jrepo, path, jtree)
         treewalk.enter_subtree

--- a/lib/rjgit.rb
+++ b/lib/rjgit.rb
@@ -68,7 +68,7 @@ module RJGit
     def self.ls_tree(repository, path=nil, treeish=Constants::HEAD, options={})
       options = {recursive: false, print: false, io: $stdout, path_filter: nil}.merge options
       jrepo = RJGit.repository_type(repository)
-      ref = treeish.respond_to?(:get_name) ? treeish.id : treeish
+      ref = treeish.respond_to?(:get_name) ? treeish.get_name : treeish
 
       begin
         obj = jrepo.resolve(ref)

--- a/lib/rjgit.rb
+++ b/lib/rjgit.rb
@@ -66,7 +66,7 @@ module RJGit
     end
     
     def self.ls_tree(repository, path=nil, ref=Constants::HEAD, options={})
-      options = {recursive: false, print: false, io: $stdout, path_filter: nil, ref: Constants::HEAD}.merge options
+      options = {recursive: false, print: false, io: $stdout, path_filter: nil}.merge options
       jrepo = RJGit.repository_type(repository)
       obj = jrepo.resolve(ref)
       walk = RevWalk.new(jrepo)

--- a/lib/rjgit.rb
+++ b/lib/rjgit.rb
@@ -68,7 +68,7 @@ module RJGit
     def self.ls_tree(repository, path=nil, treeish=Constants::HEAD, options={})
       options = {recursive: false, print: false, io: $stdout, path_filter: nil}.merge options
       jrepo = RJGit.repository_type(repository)
-      ref = treeish.respond_to?(:id) ? treeish.id : treeish
+      ref = treeish.respond_to?(:get_name) ? treeish.id : treeish
 
       begin
         obj = jrepo.resolve(ref)

--- a/lib/rjgit.rb
+++ b/lib/rjgit.rb
@@ -65,12 +65,14 @@ module RJGit
       return bytes.to_a.pack('c*').force_encoding('UTF-8')
     end
     
-    def self.ls_tree(repository, path=nil, ref=Constants::HEAD, options={})
+    def self.ls_tree(repository, path=nil, treeish=Constants::HEAD, options={})
       options = {recursive: false, print: false, io: $stdout, path_filter: nil}.merge options
       jrepo = RJGit.repository_type(repository)
-      obj = jrepo.resolve(ref)
-      walk = RevWalk.new(jrepo)
+      ref = treeish.respond_to?(:id) ? treeish.id : treeish
+
       begin
+        obj = jrepo.resolve(ref)
+        walk = RevWalk.new(jrepo)
         revobj = walk.parse_any(obj)
         jtree = case revobj.get_type
         when Constants::OBJ_TREE
@@ -83,6 +85,7 @@ module RJGit
       end
       if path
         treewalk = TreeWalk.forPath(jrepo, path, jtree)
+        return nil unless treewalk
         treewalk.enter_subtree
       else
         treewalk = TreeWalk.new(jrepo)

--- a/lib/rjgit.rb
+++ b/lib/rjgit.rb
@@ -65,24 +65,60 @@ module RJGit
       return bytes.to_a.pack('c*').force_encoding('UTF-8')
     end
     
-    def self.ls_tree(repository, tree=nil, options={})
-      options = {:recursive => false, :print => false, :io => $stdout, :ref => Constants::HEAD}.merge options
+    # def self.ls_tree(repository, tree=nil, options={})
+    #   options = {:recursive => false, :print => false, :io => $stdout, :ref => Constants::HEAD}.merge options
+    #   jrepo = RJGit.repository_type(repository)
+    #   return nil unless jrepo
+    #   if tree 
+    #     jtree = RJGit.tree_type(tree)
+    #   else
+    #     last_commit_hash = jrepo.resolve(options[:ref])
+    #     return nil unless last_commit_hash
+    #     walk = RevWalk.new(jrepo)
+    #     jcommit = walk.parse_commit(last_commit_hash)
+    #     jtree = jcommit.get_tree
+    #   end
+    #   treewalk = TreeWalk.new(jrepo)
+    #   treewalk.set_recursive(options[:recursive])
+    #   treewalk.set_filter(PathFilter.create(options[:file_path])) if options[:file_path]
+    #   treewalk.add_tree(jtree)
+    #   entries = []
+    #   while treewalk.next
+    #     entry = {}
+    #     mode = treewalk.get_file_mode(0)
+    #     entry[:mode] = mode.get_bits
+    #     entry[:type] = Constants.type_string(mode.get_object_type)
+    #     entry[:id]   = treewalk.get_object_id(0).name
+    #     entry[:path] = treewalk.get_path_string
+    #     entries << entry
+    #   end
+    #   options[:io].puts RJGit.stringify(entries) if options[:print]
+    #   return entries
+    # end
+    
+    def self.ls_tree(repository, path=nil, ref=Constants::HEAD, options={})
+      options = {recursive: false, print: false, io: $stdout, path_filter: nil, ref: Constants::HEAD}.merge options
       jrepo = RJGit.repository_type(repository)
-      return nil unless jrepo
-      if tree 
-        jtree = RJGit.tree_type(tree)
-      else
-        last_commit_hash = jrepo.resolve(options[:ref])
-        return nil unless last_commit_hash
-        walk = RevWalk.new(jrepo)
-        jcommit = walk.parse_commit(last_commit_hash)
-        jtree = jcommit.get_tree
+      obj = jrepo.resolve(ref)
+      walk = RevWalk.new(jrepo)
+      begin
+        jcommit = walk.parse_commit(obj)
+      rescue Java::OrgEclipseJgitErrors::MissingObjectException, Java::JavaLang::IllegalArgumentException, Java::JavaLang::NullPointerException
+        return nil
       end
-      treewalk = TreeWalk.new(jrepo)
+      jtree = jcommit.get_tree
+      if path
+        treewalk = TreeWalk.forPath(jrepo, path, jtree)
+        treewalk.enter_subtree
+        $stderr.puts "Must not ignore first entry! #{treewalk.get_path_string}"
+      else
+        treewalk = TreeWalk.new(jrepo)
+        treewalk.add_tree(jtree)
+      end
       treewalk.set_recursive(options[:recursive])
-      treewalk.set_filter(PathFilter.create(options[:file_path])) if options[:file_path]
-      treewalk.add_tree(jtree)
+      treewalk.set_filter(PathFilter.create(options[:path_filter])) if options[:path_filter]
       entries = []
+    
       while treewalk.next
         entry = {}
         mode = treewalk.get_file_mode(0)
@@ -93,8 +129,8 @@ module RJGit
         entries << entry
       end
       options[:io].puts RJGit.stringify(entries) if options[:print]
-      return entries
-    end
+      entries
+    end  
       
     def self.blame(repository, file_path, options={})
       options = {:print => false, :io => $stdout}.merge(options)
@@ -200,15 +236,15 @@ module RJGit
         untouched_objects = {}
         formatter = TreeFormatter.new
         treemap ||= self.treemap
-
-        if start_tree then
+        $stderr.puts "in build_tree, happily building a tree"
+        if start_tree
           treewalk = TreeWalk.new(@jrepo)
           treewalk.add_tree(start_tree)
           while treewalk.next
             filename = treewalk.get_name_string
-            if treemap.keys.include?(filename) then
+            if treemap.keys.include?(filename)
               kind = treewalk.isSubtree ? :tree : :blob
-                if treemap[filename] == false then
+                if treemap[filename] == false
                   @log[:deleted] << [kind, filename, treewalk.get_object_id(0)]
                 else
                   existing_trees[filename] = treewalk.get_object_id(0) if kind == :tree
@@ -220,9 +256,9 @@ module RJGit
             end
           end
         end
-    
-        sorted_treemap = treemap.inject({}) {|h, (k,v)| v.is_a?(Hash) ? h["#{k}/"] = v : h[k] = v; h }.merge(untouched_objects).sort
         
+        sorted_treemap = treemap.inject({}) {|h, (k,v)| v.is_a?(Hash) ? h["#{k}/"] = v : h[k] = v; h }.merge(untouched_objects).sort
+        $stderr.puts "we have a sorted_treemap: #{sorted_treemap.inspect}"
         sorted_treemap.each do |object_name, data|
           case data
             when Array
@@ -239,7 +275,7 @@ module RJGit
               @log[:added] << [:blob, object_name, blobid]
             end
         end
-    
+        $stderr.puts "trying to insert object with object_inserter"
         object_inserter.insert(formatter)
       end
       

--- a/lib/tag.rb
+++ b/lib/tag.rb
@@ -6,6 +6,7 @@ module RJGit
   class Tag
 
     attr_reader :id, :jtag
+    alias_method :get_name, :id
     RJGit.delegate_to(RevTag, :@jtag)
     
     def initialize(jtag)

--- a/lib/tree.rb
+++ b/lib/tree.rb
@@ -28,7 +28,7 @@ module RJGit
     def contents_array
       return @contents_ary if @contents_ary
       results = []
-      RJGit::Porcelain.ls_tree(@jrepo, @path, Constants::HEAD).each do |item|
+      RJGit::Porcelain.ls_tree(@jrepo, nil, @id).each do |item|
         walk = RevWalk.new(@jrepo)
         results << Tree.new(@jrepo, item[:mode], item[:path], walk.lookup_tree(ObjectId.from_string(item[:id]))) if item[:type] == 'tree'
         results << Blob.new(@jrepo, item[:mode], item[:path], walk.lookup_blob(ObjectId.from_string(item[:id]))) if item[:type] == 'blob'

--- a/lib/tree.rb
+++ b/lib/tree.rb
@@ -60,10 +60,8 @@ module RJGit
     def self.new_from_hashmap(repository, hashmap, base_tree = nil)
       jrepo = RJGit.repository_type(repository)
       tree_builder = Plumbing::TreeBuilder.new(jrepo)
-      $stderr.puts "we have a tree_builder: #{tree_builder.inspect}"
       base_tree = RJGit.tree_type(base_tree)
       new_tree = tree_builder.build_tree(base_tree, hashmap, true)
-      $stderr.puts "we have a new tree as well: #{new_tree.inspect}"
       walk = RevWalk.new(jrepo)
       new_tree = walk.lookup_tree(new_tree)
       Tree.new(jrepo, TREE_TYPE, nil, new_tree)

--- a/lib/tree.rb
+++ b/lib/tree.rb
@@ -6,6 +6,7 @@ module RJGit
   class Tree 
 
     attr_reader :contents, :id, :mode, :name, :repo, :path, :jtree
+    alias_method :get_name, :id
     RJGit.delegate_to(RevTree, :@jtree)
     include Enumerable
     

--- a/spec/blob_spec.rb
+++ b/spec/blob_spec.rb
@@ -9,6 +9,11 @@ describe Blob do
       @blob = Blob.find_blob(@repo.jrepo, 'materialist.txt')
     end
 
+    it "has an id" do
+      expect(@blob.id).to eq 'a423c5f31d193218799b533a6dbdb1052b45505f'
+      expect(@blob.get_name).to eq 'a423c5f31d193218799b533a6dbdb1052b45505f'
+    end
+
     it "has a mode" do
       expect(@blob.mode).to eql REG_FILE_TYPE
     end

--- a/spec/commit_spec.rb
+++ b/spec/commit_spec.rb
@@ -41,6 +41,7 @@ describe Commit do
 
     it "has an id" do
       expect(@commit.id).to match /ca8a30f5a7f0f163bbe3b6f0abf18a6c83b0687a/
+      expect(@commit.get_name).to match /ca8a30f5a7f0f163bbe3b6f0abf18a6c83b0687a/
     end
   
     it "points to a tree" do

--- a/spec/rjgit_spec.rb
+++ b/spec/rjgit_spec.rb
@@ -99,6 +99,10 @@ describe RJGit do
           listing = RJGit::Porcelain.ls_tree(@bare_repo.jrepo, 'lib/grit', tree, {recursive: false})
           first_entry = listing.first
           expect(first_entry[:path]).to eq 'lib/grit/actor.rb'
+          jtree = @bare_repo.head.tree.jtree
+          listing = RJGit::Porcelain.ls_tree(@bare_repo.jrepo, 'lib/grit', tree, {recursive: false})
+          first_entry = listing.first
+          expect(first_entry[:path]).to eq 'lib/grit/actor.rb'
         end
 
         it "mimics git-ls-tree for a specific path" do

--- a/spec/rjgit_spec.rb
+++ b/spec/rjgit_spec.rb
@@ -64,25 +64,34 @@ describe RJGit do
           expect(first_entry[:path]).to eq '.gitignore'
         end
         
-        it "mimics git-ls-tree for a specific tree" do
-          skip("fails due to bug in ls-tree implementation")
-          tree = RJGit::Tree.find_tree(@bare_repo, 'lib')
-          listing = RJGit::Porcelain.ls_tree(@bare_repo.jrepo, tree, {recursive: false})
+        it "mimics git-ls-tree for a specific path" do
+          listing = RJGit::Porcelain.ls_tree(@bare_repo.jrepo, 'lib', Constants::HEAD, {recursive: false})
           first_entry = listing.first
-          expect(first_entry[:path]).to eq 'grit.rb'
-          tree = RJGit::Tree.find_tree(@bare_repo, 'lib/grit')
-          listing = RJGit::Porcelain.ls_tree(@bare_repo.jrepo, tree, {recursive: false})
+          expect(first_entry[:path]).to eq 'lib/grit.rb'
+          listing = RJGit::Porcelain.ls_tree(@bare_repo.jrepo, 'lib/grit', Constants::HEAD, {recursive: false})
           first_entry = listing.first
-          expect(first_entry[:path]).to eq 'grit/actor.rb'
+          expect(first_entry[:path]).to eq 'lib/grit/actor.rb'
+        end
+        
+        it "mimics git-ls-tree for a specific commit" do
+          sha = '8bfefdbc0d901a6e8ccd27b9f20879d109f49c03'
+          listing = RJGit::Porcelain.ls_tree(@bare_repo.jrepo, nil, sha, {recursive: false})
+          expect(listing.length).to eq 7
         end
 
         it "mimics git-ls-tree recursively" do
-          listing = RJGit::Porcelain.ls_tree(@bare_repo.jrepo, nil, {recursive: true})
+          listing = RJGit::Porcelain.ls_tree(@bare_repo.jrepo, nil, Constants::HEAD, {recursive: true})
           expect(listing.length).to eq 539
+        end
+        
+        it "mimics git-ls-tree recursively for a specific path" do
+          listing = RJGit::Porcelain.ls_tree(@bare_repo.jrepo, 'lib/grit/git-ruby', Constants::HEAD, {recursive: true})
+          first_entry = listing.first
+          expect(first_entry[:path]).to eq 'lib/grit/git-ruby/internal/loose.rb'
         end
 
         it "mimics git-ls-tree for a specific path" do
-          listing = RJGit::Porcelain.ls_tree(@bare_repo.jrepo, nil, {file_path: 'lib'})
+          listing = RJGit::Porcelain.ls_tree(@bare_repo.jrepo, nil, Constants::HEAD, {path_filter: 'lib'})
           expect(listing.length).to eq 1
         end
 
@@ -90,7 +99,7 @@ describe RJGit do
     
     it "mimics git-blame" do
       RJGit::Porcelain.blame(@bare_repo, 'lib/grit.rb')
-      skip("no expectation defined.")
+      skip
     end
     
       context "producing diffs" do

--- a/spec/rjgit_spec.rb
+++ b/spec/rjgit_spec.rb
@@ -89,6 +89,17 @@ describe RJGit do
           first_entry = listing.first
           expect(first_entry[:path]).to eq 'lib/grit/git-ruby/internal/loose.rb'
         end
+        
+        it "mimics git-ls-tree for a specific treeish object" do
+          commit = @bare_repo.commits.last
+          listing = RJGit::Porcelain.ls_tree(@bare_repo.jrepo, 'lib/grit', commit, {recursive: false})
+          first_entry = listing.first
+          expect(first_entry[:path]).to eq 'lib/grit/commit.rb'
+          tree = @bare_repo.head.tree
+          listing = RJGit::Porcelain.ls_tree(@bare_repo.jrepo, 'lib/grit', tree, {recursive: false})
+          first_entry = listing.first
+          expect(first_entry[:path]).to eq 'lib/grit/actor.rb'
+        end
 
         it "mimics git-ls-tree for a specific path" do
           listing = RJGit::Porcelain.ls_tree(@bare_repo.jrepo, nil, Constants::HEAD, {path_filter: 'lib'})

--- a/spec/tag_spec.rb
+++ b/spec/tag_spec.rb
@@ -8,6 +8,7 @@ describe Tag do
   
   it "has an id" do
     expect(@tag.id).to match /f0055fda16c18fd8b27986dbf038c735b82198d7/
+    expect(@tag.get_name).to match /f0055fda16c18fd8b27986dbf038c735b82198d7/
   end
   
   it "has a name" do

--- a/spec/tree_spec.rb
+++ b/spec/tree_spec.rb
@@ -70,7 +70,7 @@ describe Tree do
   end
   
   context "creating trees" do
-    before(:all) do
+    before(:each) do
       @temp_repo_path = create_temp_repo(TEST_REPO_PATH)
       @repo = Repo.new(@temp_repo_path)
     end
@@ -80,6 +80,10 @@ describe Tree do
       it "creates a new tree from a hashmap" do
         @tree = Tree.new_from_hashmap(@repo, {"bla" => "bla", "tree" => {"blabla" => "blabla"}})
         expect(@repo.find(@tree.id, :tree)).to be_kind_of Tree
+        
+        commit = RJGit::Commit.new_with_tree(@repo, @tree, "Committing new tree", RJGit::Actor.new('rspec', 'rspec@rjgit.com'))
+        @repo.update_ref(commit)
+        
         expect(@tree.trees.find {|x| x.name == "tree"}).to be_kind_of Tree
         expect(@tree.blobs.first.name).to eq "bla"
       end
@@ -87,13 +91,15 @@ describe Tree do
       it "creates a new tree from a hashmap, based on an old tree" do
         second_tree = Tree.new_from_hashmap(@repo, {"newblob" => "data"}, @repo.head.tree)
         expect(@repo.find(second_tree.id, :tree)).to be_kind_of Tree
+        commit = RJGit::Commit.new_with_tree(@repo, second_tree, "Committing new tree", RJGit::Actor.new('rspec', 'rspec@rjgit.com'))
+        @repo.update_ref(commit)
         expect(second_tree.blobs.length).to eq 6
         expect(second_tree.blobs.find {|x| x.name == "newblob"}).to be_kind_of Blob
       end
     
     end
     
-    after(:all) do
+    after(:each) do
       remove_temp_repo(@temp_repo_path)
     end
   end

--- a/spec/tree_spec.rb
+++ b/spec/tree_spec.rb
@@ -10,7 +10,7 @@ describe Tree do
     end
 
     it "has contents" do
-      contents = RJGit::Porcelain.ls_tree(@bare_repo.jrepo, @tree.jtree)
+      contents = RJGit::Porcelain.ls_tree(@bare_repo.jrepo, @tree.path)
       expect(contents).to be_an Array
       expect(contents.first[:type]).to eq "blob"
       expect(contents.first[:id]).to match /77aa887449c28a922a660b2bb749e4127f7664e5/
@@ -79,7 +79,9 @@ describe Tree do
     
       it "creates a new tree from a hashmap" do
         @tree = Tree.new_from_hashmap(@repo, {"bla" => "bla", "tree" => {"blabla" => "blabla"}})
+        $stderr.puts "We made a tree: #{@tree}"
         expect(@repo.find(@tree.id, :tree)).to be_kind_of Tree
+        $stderr.puts "All trees in @tree: #{@tree.trees.inspect}"
         expect(@tree.trees.find {|x| x.name == "tree"}).to be_kind_of Tree
         expect(@tree.blobs.first.name).to eq "bla"
       end

--- a/spec/tree_spec.rb
+++ b/spec/tree_spec.rb
@@ -70,7 +70,7 @@ describe Tree do
   end
   
   context "creating trees" do
-    before(:each) do
+    before(:all) do
       @temp_repo_path = create_temp_repo(TEST_REPO_PATH)
       @repo = Repo.new(@temp_repo_path)
     end
@@ -79,11 +79,7 @@ describe Tree do
     
       it "creates a new tree from a hashmap" do
         @tree = Tree.new_from_hashmap(@repo, {"bla" => "bla", "tree" => {"blabla" => "blabla"}})
-        expect(@repo.find(@tree.id, :tree)).to be_kind_of Tree
-        
-        commit = RJGit::Commit.new_with_tree(@repo, @tree, "Committing new tree", RJGit::Actor.new('rspec', 'rspec@rjgit.com'))
-        @repo.update_ref(commit)
-        
+        expect(@repo.find(@tree.id, :tree)).to be_kind_of Tree        
         expect(@tree.trees.find {|x| x.name == "tree"}).to be_kind_of Tree
         expect(@tree.blobs.first.name).to eq "bla"
       end
@@ -91,15 +87,13 @@ describe Tree do
       it "creates a new tree from a hashmap, based on an old tree" do
         second_tree = Tree.new_from_hashmap(@repo, {"newblob" => "data"}, @repo.head.tree)
         expect(@repo.find(second_tree.id, :tree)).to be_kind_of Tree
-        commit = RJGit::Commit.new_with_tree(@repo, second_tree, "Committing new tree", RJGit::Actor.new('rspec', 'rspec@rjgit.com'))
-        @repo.update_ref(commit)
         expect(second_tree.blobs.length).to eq 6
         expect(second_tree.blobs.find {|x| x.name == "newblob"}).to be_kind_of Blob
       end
     
     end
     
-    after(:each) do
+    after(:all) do
       remove_temp_repo(@temp_repo_path)
     end
   end

--- a/spec/tree_spec.rb
+++ b/spec/tree_spec.rb
@@ -44,6 +44,7 @@ describe Tree do
 
     it "has an id" do
       expect(@tree.id).to match /aa74200714ce8190b38211795f974b4410f5a9d0/
+      expect(@tree.get_name).to match /aa74200714ce8190b38211795f974b4410f5a9d0/
     end
 
     it "has a mode" do

--- a/spec/tree_spec.rb
+++ b/spec/tree_spec.rb
@@ -79,9 +79,7 @@ describe Tree do
     
       it "creates a new tree from a hashmap" do
         @tree = Tree.new_from_hashmap(@repo, {"bla" => "bla", "tree" => {"blabla" => "blabla"}})
-        $stderr.puts "We made a tree: #{@tree}"
         expect(@repo.find(@tree.id, :tree)).to be_kind_of Tree
-        $stderr.puts "All trees in @tree: #{@tree.trees.inspect}"
         expect(@tree.trees.find {|x| x.name == "tree"}).to be_kind_of Tree
         expect(@tree.blobs.first.name).to eq "bla"
       end


### PR DESCRIPTION
* Fixes https://github.com/repotag/rjgit/issues/15
* New method signature
* Breaks backwards compatibility
* Allows sha strings, commits, trees, etc. to be passed in