### PR TITLE
Fix Commit#parents. Resolves https://github.com/repotag/rjgit/issues/14.

### DIFF
--- a/lib/commit.rb
+++ b/lib/commit.rb
@@ -38,7 +38,9 @@ module RJGit
     end
   
     def parents
-      @parents ||= @jcommit.get_parents.map {|parent| Commit.new(@jrepo, parent)}
+      @parents ||= @jcommit.get_parents.map do |parent|
+        RJGit::Commit.new(@jrepo, RevWalk.new(@jrepo).parseCommit(parent.get_id))
+      end
     end
 
     def stats

--- a/spec/commit_spec.rb
+++ b/spec/commit_spec.rb
@@ -60,6 +60,9 @@ describe Commit do
     it "has parent commits" do
       expect(@commit.parents).to be_an Array
       expect(@commit.parents.first.id).to match /3fa4e130fa18c92e3030d4accb5d3e0cadd40157/
+      head = @bare_repo.head
+      expect(head.parents).to be_an Array
+      expect(head.parents.first.id).to match /3fa4e130fa18c92e3030d4accb5d3e0cadd40157/
     end
   
     it "has a message" do


### PR DESCRIPTION
Apparently, `jcommit.get_parents` returns incomplete RevCommit objects by default (for efficiency reasons). This causes `getAuthorIdent` to return `null` on initialization of the `RJGit::Commit` object. Parsing the ObjectId first resolves this issue (though it is somewhat costly).