### PR TITLE
Add ability to specify git_dir to repo.

### DIFF
--- a/lib/repo.rb
+++ b/lib/repo.rb
@@ -42,7 +42,15 @@ module RJGit
     
     def initialize(path, options = {})
       epath = File.expand_path(path)
-      gitpath = File.join(epath, '.git')
+      if options[:git_dir]
+        if (Pathname.new options[:git_dir]).absolute?
+          gitpath = options[:git_dir]
+        else
+          gitpath = File.join(epath, options[:git_dir])
+        end
+      else
+        gitpath = File.join(epath, '.git')
+      end
       
       # Default value for bare
       bare = false
@@ -61,7 +69,7 @@ module RJGit
       @path = bare ? epath : gitpath
       @config = RJGit::Configuration.new(File.join(@path, 'config'))
       repo_path = java.io.File.new(@path)
-      @jrepo = bare ? RepositoryBuilder.new().set_bare.set_git_dir(repo_path).build() : RepositoryBuilder.new().set_git_dir(repo_path).build()
+      @jrepo = bare ? RepositoryBuilder.new().set_bare.set_git_dir(repo_path).build() : RepositoryBuilder.new().set_git_dir(repo_path).set_work_tree(java.io.File.new(epath)).build()
       @jrepo.create(bare) if options[:create]
       @git = RubyGit.new(@jrepo)
     end

--- a/spec/repo_spec.rb
+++ b/spec/repo_spec.rb
@@ -7,11 +7,11 @@ describe LocalRefWriter do
     @repo = Repo.new(@temp_repo_path)
     @writer = LocalRefWriter.new(@repo.jrepo.get_all_refs, @repo.path)
   end
-  
+
   it "has a path variable set at initialization" do
     expect(@writer.path).to eql @repo.path
   end
-  
+
   it "writes to the specified file path under the repository's path" do
     filename = File.join('info','nonexistent')
     newfile = File.join(@repo.path, filename)
@@ -19,15 +19,15 @@ describe LocalRefWriter do
     @writer.writeFile(filename, "Test".to_java_bytes)
     expect(File.exists?(newfile)).to be true
   end
-  
+
   it "inherits the write_info_refs method from its JGit superclass" do
     expect(@writer.method(:write_info_refs).owner).to eql Java::OrgEclipseJgitLib::RefWriter
   end
-  
+
   it "throws a Java IOException when the destination file is not writable" do
     expect{ @writer.writeFile("","Test".to_java_bytes) }.to raise_error(IOException)
   end
-  
+
   after(:each) do
     remove_temp_repo(@temp_repo_path)
     @repo = nil
@@ -40,7 +40,7 @@ end
 describe Repo do
 
   context "with read-only access" do
-    
+
     before(:each) do
       @create_new = true
       @repo = Repo.new(TEST_REPO_PATH) # Test with both a bare and a non-bare repository
@@ -49,7 +49,7 @@ describe Repo do
 
     it "determines if the repository is valid" do
       tmp_path = get_new_temp_repo_path
-      
+
       expect(tmp_path).to_not exist
       new_repo = Repo.new(tmp_path, :is_bare => false, :create => false)
       expect(new_repo).to_not be_valid
@@ -58,7 +58,7 @@ describe Repo do
       FileUtils.rm_rf(File.join(tmp_path, '.git'))
       expect(new_repo).to_not be_valid
       remove_temp_repo(tmp_path)
-      
+
       expect(tmp_path).to_not exist
       bare_new_repo = Repo.new(tmp_path, :is_bare => true, :create => false)
       expect(bare_new_repo).to_not be_valid
@@ -76,24 +76,24 @@ describe Repo do
     it "has a bare path for bare repositories" do
       expect(File.basename(@bare_repo.path)).to_not eql ".git"
     end
-    
+
     it "is bare for a new repository only if specified" do
       repo = Repo.new(get_new_temp_repo_path(true), :is_bare => true)
       expect(repo).to be_bare
       repo = Repo.new(get_new_temp_repo_path)
       expect(repo).to_not be_bare
     end
-    
+
     it "allows the user to set bare even if a .git dir exists in the path" do
       repo = Repo.new(TEST_REPO_PATH, :is_bare => true)
       expect(repo).to be_bare
     end
-    
+
     it "allows the user to set non-bare even if a .git dir does not exist in the path" do
       repo = Repo.new(TEST_BARE_REPO_PATH, :is_bare => false)
       expect(repo).to_not be_bare
     end
-    
+
     it "creates a new repository on disk immediately" do
       tmp_path = get_new_temp_repo_path
       expect(tmp_path).to_not be_a_directory
@@ -102,7 +102,7 @@ describe Repo do
       remove_temp_repo(tmp_path)
       expect(new_repo).to_not be_bare
     end
-    
+
     it "creates a new bare repository on disk immediately" do
       tmp_path = get_new_temp_repo_path(true)
       expect(tmp_path).to_not be_a_directory
@@ -111,7 +111,7 @@ describe Repo do
       remove_temp_repo(tmp_path)
       expect(new_repo).to be_bare
     end
-    
+
     it "creates an existing repository object on disk" do
       tmp_path = get_new_temp_repo_path
       new_repo = Repo.new(tmp_path, :is_bare => false, :create => false)
@@ -130,7 +130,35 @@ describe Repo do
       remove_temp_repo(tmp_path)
       expect(new_bare_repo).to be_bare
     end
-    
+
+    it "creates a new repository with a different external git_dir if specified" do
+      tmp_path = get_new_temp_repo_path(false)
+      tmp_absolute_git_path = get_new_temp_repo_path(false) + "-not_normal_git_directory"
+      expect(tmp_path).to_not be_a_directory
+      expect(tmp_absolute_git_path).to_not be_a_directory
+      new_repo = Repo.new(tmp_path, :git_dir => tmp_absolute_git_path, :create => @create_new)
+      expect(tmp_path).to be_a_directory
+      expect(tmp_absolute_git_path).to be_a_directory
+      expect(new_repo).to be_valid
+      remove_temp_repo(tmp_path)
+      remove_temp_repo(tmp_absolute_git_path)
+      expect(new_repo).to_not be_bare
+    end
+
+    it "creates a new repository with a different internal git_dir if specified" do
+      tmp_path = get_new_temp_repo_path(false)
+      tmp_relative_git_path = "not_normal_git_directory"
+      tmp_absolute_git_path = File.join(tmp_path, tmp_relative_git_path)
+      expect(tmp_path).to_not be_a_directory
+      expect(tmp_absolute_git_path).to_not be_a_directory
+      new_repo = Repo.new(tmp_path, :git_dir => tmp_relative_git_path, :create => @create_new)
+      expect(tmp_path).to be_a_directory
+      expect(tmp_absolute_git_path).to be_a_directory
+      expect(new_repo).to be_valid
+      remove_temp_repo(tmp_path)
+      expect(new_repo).to_not be_bare
+    end
+
     it "wraps a JGit repository object" do
       jrepo = @repo.jrepo
       repo = Repo.new_from_jgit_repo(jrepo)
@@ -144,7 +172,7 @@ describe Repo do
       result = expect(tmp_path).to be_a_directory
       remove_temp_repo(tmp_path)
       result
-      
+
       tmp_path = get_new_temp_repo_path # non-bare repository
       expect(tmp_path).to_not exist
       new_repo = Repo.create(tmp_path, :is_bare => false)
@@ -152,7 +180,7 @@ describe Repo do
       remove_temp_repo(tmp_path)
       result
     end
-    
+
     it "informs us whether it is bare" do
       expect(@repo).to_not be_bare
       expect(@bare_repo).to be_bare
@@ -165,7 +193,7 @@ describe Repo do
     it "has a config" do
       expect(@bare_repo.config).to be_a RJGit::Configuration
     end
-    
+
     it "lists the current branch" do
       expect(@repo.branch).to eq "refs/heads/master"
     end
@@ -180,11 +208,11 @@ describe Repo do
       expect(@repo.commits).to be_an Array
       expect(@repo.commits.length).to eq 8
     end
-    
-    it "returns the latest commit (HEAD)" do    
+
+    it "returns the latest commit (HEAD)" do
       expect(@repo.head.committed_date).to eq(DateTime.parse("2015-04-03 14:27:02 +0200").to_time)
     end
-    
+
     it "lists its tags in name-id pairs" do
       expect(@bare_repo.tags(lightweight=true)).to be_a Hash
       expect(@bare_repo.tags(true)["annotated"]).to eq "b7f932bd02b3e0a4228ee7b55832749028d345de"
@@ -212,7 +240,7 @@ describe Repo do
       expect(tree.name).to eq 'lib'
       expect(tree.jtree).to be_a org.eclipse.jgit.revwalk.RevTree
     end
-    
+
     it "finds objects of all types by SHA" do
       expect(@bare_repo.find(@bare_repo.head.tree.trees.first.id, :tree)).to be_a Tree
       expect(@bare_repo.find(@bare_repo.head.tree.blobs.first.id, :blob)).to be_a Blob
@@ -230,40 +258,40 @@ describe Repo do
       @bare_repo = nil
     end
   end
-  
+
   context "with write/commit access" do
     before(:each) do
       @temp_repo_path = create_temp_repo(TEST_REPO_PATH)
       @repo = Repo.new(@temp_repo_path)
     end
-    
+
     it "adds files to itself" do
       File.open(File.join(@temp_repo_path, "rspec-addfile.txt"), 'w') {|file| file.write("This is a new file to add.") }
       @repo.add("rspec-addfile.txt")
       expect(@repo.jrepo.read_dir_cache.find_entry("rspec-addfile.txt")).to eq 6
     end
-  
+
     it "creates a branch" do
       @repo.create_branch('rspec-branch')
       expect(@repo.branches).to include('refs/heads/rspec-branch')
     end
-    
+
     it "deletes a branch" do
       @repo.delete_branch('refs/heads/alternative')
       expect(@repo.branches).to_not include('refs/heads/alternative')
     end
-    
+
     it "renames a branch" do
       @repo.rename_branch('refs/heads/alternative', 'rspec-branch')
       expect(@repo.branches).to include('refs/heads/rspec-branch')
     end
-    
+
     it "checks out a branch if clean" do
       result = @repo.git.checkout('refs/heads/alternative')
       expect(result[:success]).to be true
       expect(result[:result]).to eq 'refs/heads/alternative'
     end
-    
+
     it "does not switch branches if there are conflicts" do
       File.open(File.join(@temp_repo_path, "rspec-conflictingfile.txt"), 'w') {|file| file.write("This is a new file.") }
       @repo.add("rspec-conflictingfile.txt")
@@ -279,7 +307,7 @@ describe Repo do
       expect(result[:result]).to include 'rspec-conflictingfile.txt'
       expect(@repo.branch).to eq 'refs/heads/conflict_branch'
     end
-    
+
     it "commits files to the repository" do
       expect(RJGit::Porcelain.ls_tree(@repo)).to have(6).items
       File.open(File.join(@temp_repo_path, "newfile.txt"), 'w') {|file| file.write("This is a new file to commit.") }
@@ -288,7 +316,7 @@ describe Repo do
       expect(RJGit::Porcelain.ls_tree(@repo)).to have_at_least(7).items
       expect(@repo).to respond_to(:commit).with(2).arguments
     end
-    
+
     it "removes files from the index and the file system" do
       File.open(File.join(@temp_repo_path, "remove_file.txt"), 'w') {|file| file.write("This is a file to remove.") }
       @repo.add("remove_file.txt")
@@ -301,7 +329,7 @@ describe Repo do
       expect(diff[:changetype]).to eq 'DELETE'
       expect("#{@temp_repo_path}/remove_file.txt").to_not exist
     end
-    
+
     it "updates a ref" do
       new_tree = Tree.new_from_hashmap(@repo, {"bla" => "bla"}, @repo.head.tree)
       c = Commit.new_with_tree(@repo, new_tree, "Commit message", Actor.new("test","test@test"))
@@ -309,7 +337,7 @@ describe Repo do
       expect(@repo.update_ref(c)).to eq "FAST_FORWARD"
       expect(@repo.head.id).to eq c.id
     end
-    
+
     it "updates the server info files" do
       server_info_files = [File.join(@repo.path, 'info','refs'), File.join(@repo.path, 'objects','info','packs')]
       contents = []
@@ -326,11 +354,11 @@ describe Repo do
         f.close
       end
     end
-    
+
     after(:each) do
       remove_temp_repo(@temp_repo_path)
       @repo = nil
     end
   end
-  
+
 end


### PR DESCRIPTION
With this commit, an option, git_dir, specified to the Repo class will
allow it to have a non-standard git_dir. 