### PR TITLE
Add ssh transport to clone, push, pull, and fetch

### DIFF
--- a/spec/git_spec/dummy_ssh_transport.rb
+++ b/spec/git_spec/dummy_ssh_transport.rb
@@ -1,0 +1,7 @@
+#This class exists to get access to the ssh session factory. 
+class DummySSHTransport
+  attr_accessor :dummy_factory
+  def setSshSessionFactory(dummy_factory)
+    @dummy_factory = dummy_factory
+  end
+end


### PR DESCRIPTION
With this commit, ssh with PKI is added as a transport option for clone, push, pull, and fetch.