### PR TITLE
Tree#/ returns self when called with '/' as argument

### DIFF
--- a/lib/tree.rb
+++ b/lib/tree.rb
@@ -60,7 +60,11 @@ module RJGit
     end
     
     def /(file)
-      treewalk = TreeWalk.forPath(@jrepo, file, @jtree)
+      begin
+        treewalk = TreeWalk.forPath(@jrepo, file, @jtree)
+      rescue Java::JavaLang::IllegalArgumentException
+        return self
+      end
       treewalk.nil? ? nil : 
         wrap_tree_or_blob(treewalk.get_file_mode(0), treewalk.get_path_string, treewalk.get_object_id(0))
     end

--- a/spec/tree_spec.rb
+++ b/spec/tree_spec.rb
@@ -56,6 +56,7 @@ describe Tree do
       expect(@tree / "grit").to be_kind_of Tree
       expect(@tree / "grit/bla").to be_nil
       expect(@tree / "grit/actor.rb" ).to be_kind_of Blob
+      expect((@tree / "/").id).to eq @tree.id
     end
 
     it "has an id" do


### PR DESCRIPTION
I discovered a discrepancy between the current and previous implementation of `Tree#/` (change in 4efbf761373a80835a3a11c00ae7caad0a21c0ab). Previously it would return `self` when the `file` argument equalled `"/"`. In the current implementation, that would trigger a jgit argument error ("Empty path not permitted").