### PR TITLE
Require URI

### DIFF
--- a/lib/rjgit.rb
+++ b/lib/rjgit.rb
@@ -11,6 +11,7 @@ module RJGit
     VERSION
   end
   
+  require 'uri'
   require 'stringio'
   # gem requires
   require 'mime/types'


### PR DESCRIPTION
This is used in lib/git.rb but not required anywhere.

This leads to crashes unless required manually.