### PR TITLE
Refactor Tree#/

### DIFF
--- a/lib/tree.rb
+++ b/lib/tree.rb
@@ -60,13 +60,13 @@ module RJGit
     end
     
     def /(file)
-      begin
+      if file =~ /^\/+$/
+        self
+      else
         treewalk = TreeWalk.forPath(@jrepo, file, @jtree)
-      rescue Java::JavaLang::IllegalArgumentException
-        return self
+        treewalk.nil? ? nil : 
+          wrap_tree_or_blob(treewalk.get_file_mode(0), treewalk.get_path_string, treewalk.get_object_id(0))
       end
-      treewalk.nil? ? nil : 
-        wrap_tree_or_blob(treewalk.get_file_mode(0), treewalk.get_path_string, treewalk.get_object_id(0))
     end
     
     def self.new_from_hashmap(repository, hashmap, base_tree = nil)


### PR DESCRIPTION
Going through this project's history I noticed that currently, the `Tree#/` method uses exception-catching to return the proper tree (`self`) in case the argument is `'/'`. This was introduced as a fix in https://github.com/repotag/rjgit/pull/29, as before calling `tree / '/'` would raise a jgit argument error ("Empty path not permitted"). But I think using exceptions to determine flow like that is not very clean (what if an argument error is thrown for some other reason?). Hence this alternative attempt at dealing with `'/'` as an argument.