### PR TITLE
Implement ApplyPatchToIndex Class

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,12 +1,12 @@
 source 'https://rubygems.org'
 
-gem "mime-types", "~> 2.6.2" 
-gem "rake", "~> 10.4.2"
+gem 'mime-types', '~> 2.6.2'
+gem 'rake', '>= 12.3.3'
 
-gem 'coveralls', require: false
+gem 'coveralls', '~> 0.8.23', require: false
 
 group :test do
-  gem "rspec", "~> 3.4.0"
-  gem "rspec-collection_matchers", "~> 1.1.2"
-  gem "simplecov"
+  gem 'rspec', '~> 3.4.0'
+  gem 'rspec-collection_matchers', '~> 1.1.2'
+  gem 'simplecov'
 end

--- a/lib/commit.rb
+++ b/lib/commit.rb
@@ -100,12 +100,12 @@ module RJGit
       Commit.new(repository, RevWalk.new(repository).parseCommit(new_commit))
     end
     
-    def self.find_head(repository)
+    def self.find_head(repository, ref = Constants::HEAD)
       repository = RJGit.repository_type(repository)
       return nil if repository.nil?
       begin
         walk = RevWalk.new(repository)
-        objhead = repository.resolve(Constants::HEAD)
+        objhead = repository.resolve(ref)
         return Commit.new(repository, walk.parseCommit(objhead))
       rescue java.lang.NullPointerException => e
         return nil

--- a/lib/git.rb
+++ b/lib/git.rb
@@ -289,7 +289,11 @@ module RJGit
     end
 
     def apply(input_stream)
-      apply_result = @jgit.apply.set_patch(input_stream).call
+      begin
+        apply_result = @jgit.apply.set_patch(input_stream).call
+      rescue Java::OrgEclipseJgitApiErrors::PatchApplyException
+        RJGit::PatchApplyException
+      end
       updated_files = apply_result.get_updated_files
       updated_files_parsed = []
       updated_files.each do |file|

--- a/lib/git.rb
+++ b/lib/git.rb
@@ -15,6 +15,8 @@ module RJGit
   import 'org.eclipse.jgit.api.TransportConfigCallback'
   import 'org.eclipse.jgit.transport.JschConfigSessionFactory'
   import 'org.eclipse.jgit.transport.SshTransport'
+  
+  class PatchApplyException < StandardError; end
 
   class RubyGit
 
@@ -292,7 +294,7 @@ module RJGit
       begin
         apply_result = @jgit.apply.set_patch(input_stream).call
       rescue Java::OrgEclipseJgitApiErrors::PatchApplyException
-        RJGit::PatchApplyException
+        raise RJGit::PatchApplyException
       end
       updated_files = apply_result.get_updated_files
       updated_files_parsed = []

--- a/lib/rjgit.rb
+++ b/lib/rjgit.rb
@@ -25,8 +25,6 @@ module RJGit
 
   import 'org.eclipse.jgit.lib.ObjectId'
   
-  class PatchApplyException < StandardError; end
-
   module Porcelain
 
     import 'org.eclipse.jgit.lib.Constants'

--- a/spec/rjgit_spec.rb
+++ b/spec/rjgit_spec.rb
@@ -7,21 +7,21 @@ describe RJGit do
     @bare_repo = Repo.new(TEST_BARE_REPO_PATH)
     @git = RubyGit.new(@bare_repo.jrepo)
   end
-  
+
   it "has a version" do
     expect(RJGit.version).to eq(RJGit::VERSION)
   end
-  
+
   context "delegating missing methods to the underlying jgit Git object" do
      it "delegates the method to the JGit object" do
        expect(@git.send(:rebase)).to be_a org.eclipse.jgit.api.RebaseCommand # :rebase method not implemented in RubyGit, but is implemented in the underlying JGit object
      end
-     
+
      it "throws an exception if the JGit object does not know the method" do
        expect { @git.send(:non_existent_method) }.to raise_error(NoMethodError)
      end
   end
-  
+
   describe Porcelain do
     before(:all) do
       @temp_repo_path = create_temp_repo(TEST_REPO_PATH)
@@ -29,22 +29,22 @@ describe RJGit do
       @testfile = 'test_file.txt'
       File.open(File.join(@temp_repo_path, @testfile), 'w') {|file| file.write("This is a new file to add.") }
     end
-    
+
     it "looks up the object belonging to a tag" do
       @repo.git.tag('v0.0', 'initial state commit for a specific commit', @repo.head.jcommit)
       expect(RJGit::Porcelain.object_for_tag(@repo, @repo.tags.first.last)).to be_kind_of Commit
     end
-    
+
     it "mimics git-cat-file" do
       blob = @bare_repo.blob('lib/grit.rb')
       expect(RJGit::Porcelain.cat_file(@bare_repo, blob.jblob)).to match /# core\n/
     end
-    
+
     it "adds files to a repository" do
       Porcelain.add(@repo, @testfile)
       expect(@repo.jrepo.read_dir_cache.find_entry(@testfile).size).to eq 8
     end
-    
+
     it "commits files to a repository" do
       message = "Initial commit"
       Porcelain.commit(@repo, message)
@@ -52,7 +52,7 @@ describe RJGit do
     end
 
       context "listing trees" do
-    
+
         it "mimics git-ls-tree" do
           listing = RJGit::Porcelain.ls_tree(@bare_repo.jrepo)
           expect(listing).to be_an Array
@@ -63,7 +63,7 @@ describe RJGit do
           expect(first_entry[:id]).to match /baaa47163a922b716898936f4ab032db4e08ae8a/
           expect(first_entry[:path]).to eq '.gitignore'
         end
-        
+
         it "mimics git-ls-tree for a specific path" do
           listing = RJGit::Porcelain.ls_tree(@bare_repo.jrepo, 'lib', Constants::HEAD, {recursive: false})
           first_entry = listing.first
@@ -72,7 +72,7 @@ describe RJGit do
           first_entry = listing.first
           expect(first_entry[:path]).to eq 'lib/grit/actor.rb'
         end
-        
+
         it "mimics git-ls-tree for a specific commit" do
           sha = '8bfefdbc0d901a6e8ccd27b9f20879d109f49c03'
           listing = RJGit::Porcelain.ls_tree(@bare_repo.jrepo, nil, sha, {recursive: false})
@@ -83,13 +83,13 @@ describe RJGit do
           listing = RJGit::Porcelain.ls_tree(@bare_repo.jrepo, nil, Constants::HEAD, {recursive: true})
           expect(listing.length).to eq 539
         end
-        
+
         it "mimics git-ls-tree recursively for a specific path" do
           listing = RJGit::Porcelain.ls_tree(@bare_repo.jrepo, 'lib/grit/git-ruby', Constants::HEAD, {recursive: true})
           first_entry = listing.first
           expect(first_entry[:path]).to eq 'lib/grit/git-ruby/internal/loose.rb'
         end
-        
+
         it "mimics git-ls-tree for a specific treeish object" do
           commit = @bare_repo.commits.last
           listing = RJGit::Porcelain.ls_tree(@bare_repo.jrepo, 'lib/grit', commit, {recursive: false})
@@ -111,12 +111,12 @@ describe RJGit do
         end
 
       end
-    
+
     it "mimics git-blame" do
       RJGit::Porcelain.blame(@bare_repo, 'lib/grit.rb')
       skip
     end
-    
+
       context "producing diffs" do
         before(:each) do
           @temp_repo_path = create_temp_repo(TEST_REPO_PATH)
@@ -144,7 +144,7 @@ describe RJGit do
         end
 
         it "returns a patch for a diff entry with optional formatting"
-      
+
         it "returns cached diff when adding file" do
           entry = RJGit::Porcelain.diff(@repo, {cached: true}).first
           expect(entry).to be_a Hash
@@ -153,8 +153,8 @@ describe RJGit do
           @repo.commit("Committing a test file to a test repository.")
           expect(RJGit::Porcelain.diff(@repo)).to eq []
         end
-      
-        it "returns cached diff when removing file" do 
+
+        it "returns cached diff when removing file" do
           @repo.commit("Adding rspec-addfile.txt so it can be deleted.")
           @repo.remove("rspec-addfile.txt")
           entry = RJGit::Porcelain.diff(@repo, {cached: true}).first
@@ -163,22 +163,22 @@ describe RJGit do
           @repo.commit("Removing test file.")
           expect(RJGit::Porcelain.diff(@repo)).to eq []
         end
-      
+
         after(:each) do
           @repo = nil
 	        remove_temp_repo(@temp_repo_path)
-        end 
+        end
       end
-    
+
     after(:all) do
       @repo = nil
       remove_temp_repo(@temp_repo_path)
     end
-    
+
   end # end Porcelain
-  
+
   describe Plumbing do
-    
+
     describe RJGit::Plumbing::Index do
       before(:all) do
         @temp_repo_path = get_new_temp_repo_path(true)
@@ -187,33 +187,33 @@ describe RJGit do
         @msg = "Message"
         @auth = RJGit::Actor.new("test", "test@repotag.org")
       end
-      
+
       it "has a treemap" do
         expect(@index.treemap).to be_kind_of Hash
       end
-      
+
       it "adds blobs to the treemap" do
         @index.add("test", "Test")
         expect(@index.treemap["test"]). to eq "Test"
       end
-      
+
       it "adds trees to the treemap" do
         @index.add("tree/blob", "Test")
         expect(@index.treemap["tree"]).to eq({"blob" => "Test"})
       end
-      
+
       it "adds items to delete to the treemap" do
         @index.delete("tree/blob")
         expect(@index.treemap["tree"]["blob"]).to be false
       end
-      
+
       it "adds commits to an empty repository" do
         res, log = @index.commit(@msg, @auth)
         expect(res).to eq "NEW"
         expect(@repo.blob("test").data).to eq "Test"
         expect(@repo.commits.first.parents).to be_empty
       end
-      
+
       it "adds commits with a parent commit" do
         @index.add("tree/blob", "Test")
         res, log = @index.commit(@msg, @auth)
@@ -221,27 +221,27 @@ describe RJGit do
         expect(@repo.blob("tree/blob").data).to eq "Test"
         expect(@repo.commits.first.parents).to_not be_empty
       end
-      
+
       it "returns log information after commit" do
         @index.add("tree/blob2", "Tester")
         res, log = @index.commit(@msg, @auth)
         expect(log[:added].select {|x| x.include?("tree")}.first).to include(:tree)
       end
-      
+
       it "commits to a non-default branch" do
         msg = "Branch test"
         @index.add("tree/blob3", "More testing")
         res, log = @index.commit(msg, @auth, nil, "refs/heads/newbranch")
         expect(@repo.commits("newbranch").first.message).to eq msg
       end
-      
+
       it "allows setting multiple parents for a commit" do
         @index.delete("tree/blob2")
         parents = [@repo.commits.first, @repo.commits.last]
         res, log = @index.commit(@msg, @auth, parents)
         expect(@repo.commits.first.parents.length).to eq 2
       end
-      
+
       it "allows setting the departure tree when building a new commit" do
         @index.add("newtree/blobinnewtree", "contents")
         res, log = @index.commit(@msg, @auth)
@@ -253,21 +253,21 @@ describe RJGit do
         expect(@repo.blob("secondblob").data).to eq "other contents"
         @index.current_tree = nil
       end
-      
+
       it "tells whether a response code indicates a successful response" do
         ["NEW", "FAST_FORWARD"].each do |s|
           expect(RJGit::Plumbing::Index.successful?(s)).to be true
         end
         expect(RJGit::Plumbing::Index.successful?("FAILED")).to be false
       end
-      
+
       after(:all) do
         remove_temp_repo(@temp_repo_path)
         @repo = nil
       end
-    
+
     end
-    
+
     describe RJGit::Plumbing::TreeBuilder do
       before(:all) do
         @temp_repo_path = get_new_temp_repo_path(true)
@@ -279,18 +279,18 @@ describe RJGit do
         @index.commit(@msg, @auth)
         @tb = RJGit::Plumbing::TreeBuilder.new(@repo)
       end
-      
+
       it "initializes with the right defaults" do
         expect(@tb.object_inserter).to be_kind_of org.eclipse.jgit.lib.ObjectInserter
         expect(@tb.treemap).to eq({})
         expect(@tb.log).to eq({deleted: [], added: [] })
       end
-      
+
       it "adds and deletes objects to a tree" do
         @tb.treemap = {"newtest/bla" => "test"}
         tree = @tb.build_tree(@repo.jrepo.resolve("refs/heads/master^{tree}"))
         expect(tree).to be_kind_of org.eclipse.jgit.lib.ObjectId
-        
+
         treewalk = TreeWalk.new(@repo.jrepo)
         treewalk.add_tree(tree)
         treewalk.set_recursive(true)
@@ -299,13 +299,13 @@ describe RJGit do
           objects << treewalk.get_path_string
         end
         expect(objects).to include("newtest/bla")
-        
+
         @index.add('newtest/bla', 'contents')
         @index.commit(@msg, @auth)
-        
+
         @tb.treemap = {"newtest" => false}
         tree = @tb.build_tree(@repo.jrepo.resolve("refs/heads/master^{tree}"))
-        
+
         treewalk = TreeWalk.new(@repo.jrepo)
         treewalk.add_tree(tree)
         treewalk.set_recursive(true)
@@ -315,7 +315,7 @@ describe RJGit do
         end
         expect(objects).to_not include("newtest/bla")
       end
-      
+
       it "logs information about added and deleted objects" do
         @tb.init_log
         @tb.treemap = {"newtest" => "test"}
@@ -327,7 +327,7 @@ describe RJGit do
         expect(@tb.log[:deleted].first).to include(:blob)
         expect(@tb.log[:deleted].first).to include("newtest")
       end
-      
+
       it "does not log information about trees that contain no added objects" do
         @tb.treemap = {"newtree/test/newblob" => "test"}
         tree = @tb.build_tree(@repo.jrepo.resolve("refs/heads/master^{tree}"))
@@ -336,21 +336,87 @@ describe RJGit do
         @tb.build_tree(tree)
         expect(@tb.log[:added]).to be_empty
       end
-      
+
       it "tells whether a given hashmap contains no added blobs" do
         expect(@tb.only_contains_deletions({'test' => {'test' => false}})).to be true
         expect(@tb.only_contains_deletions({'test' => {'test' => false, 'test2' => 'content'}})).to be false
       end
-      
+
       after(:all) do
         remove_temp_repo(@temp_repo_path)
         @repo = nil
       end
-      
+
     end
-    
+
+    describe RJGit::Plumbing::ApplyPatchToIndex do
+      before(:all) do
+        @temp_repo_path = create_temp_repo(TEST_BARE_REPO_PATH, true)
+        @repo = Repo.new(@temp_repo_path)
+        @diffs = RJGit::Porcelain.diff(@repo, patch: true, new_rev: @repo.commits[1].id, old_rev: @repo.commits[0].id)
+        @msg = 'Message'
+        @auth = RJGit::Actor.new('test', 'test@repotag.org')
+      end
+
+      after(:all) do
+        remove_temp_repo(@temp_repo_path)
+        @repo = nil
+      end
+
+      it 'converts diff entries to a patch' do
+        result = RJGit::Plumbing::ApplyPatchToIndex.diffs_to_patch(@diffs)
+        expect(result).to be_a String
+        expect(result.split("\n").first).to eq 'diff --git a/PURE_TODO b/PURE_TODO'
+      end
+
+      it 'applies a patch' do
+        head_sha = @repo.head.id
+        expect(head_sha).to eq 'ca8a30f5a7f0f163bbe3b6f0abf18a6c83b0687a'
+        patch = RJGit::Plumbing::ApplyPatchToIndex.diffs_to_patch(@diffs)
+        applier = RJGit::Plumbing::ApplyPatchToIndex.new(@repo, patch)
+        applier.build_map
+        result, log, sha = applier.commit(@msg, @auth, nil, true) # message, actor, don't specify parents (auto resolves), force update of HEAD
+        expect(result).to eq 'FORCED'
+        expect(sha).not_to eq head_sha
+        expect(@repo.head.id).to eq sha
+      end
+
+      it 'throws a PatchApplyException when using a malformed patch at init' do
+        patch = <<EOF
+@@ -109,4 +109,11 @@ assertTrue(Arrays.equals(values.toArray(), repositoryConfig
+.getStringList("my", null, "somename")));
+diff --git a/org.eclipse.jgit/src/org/spearce/jgit/lib/RepositoryConfig.java b/org.eclipse.jgit/src/org/spearce/jgit/lib/RepositoryConfig.java
+index 45c2f8a..3291bba 100644
+--- a/org.eclipse.jgit/src/org/spearce/jgit/lib/RepositoryConfig.java
++++ b/org.eclipse.jgit/src/org/spearce/jgit/lib/RepositoryConfig.java
+EOF
+        expect {RJGit::Plumbing::ApplyPatchToIndex.new(@repo, patch)}.to raise_error Java::OrgEclipseJgitApiErrors::PatchApplyException
+      end
+
+      it 'throws a PatchApplyException when encountering a malformed hunk' do
+        patch1 = <<EOF
+diff --git a/PURE_TODO b/PURE_TODO
+index a3648a1..2d44096 100644
+--- a/F2
++++ b/F2
+@@ -2,2 +2,3 @@ a
+ B
++c
+ d
+EOF
+        patch2 = <<EOF
+diff --git a/lib/grit.rb b/lib/grit.rb\nindex 77aa887..6afcf64 100644\n--- a/lib/grit.rb\n+++ b/lib/grit.rb\n@@ -30000,12 +11,10 @@\n require 'rubygems'\n require 'mime/types'\n require 'open4'\n-require 'digest/sha1'\n \n # internal requires\n require 'grit/lazy'\n require 'grit/errors'\n-require 'grit/git-ruby'\n require 'grit/git'\n require 'grit/head'\n require 'grit/tag'\n@@ -28,7 +26,6 @@\n require 'grit/config'\n require 'grit/repo'\n \n-\n module Grit\n   class << self\n     attr_accessor :debug
+EOF
+        [patch1, patch2].each do |patch|
+          applier = RJGit::Plumbing::ApplyPatchToIndex.new(@repo, patch)
+          expect {applier.build_map}.to raise_error Java::OrgEclipseJgitApiErrors::PatchApplyException
+        end
+      end
+
+    end
+
   end
-  
+
   describe "helper methods" do
     specify {expect(RJGit.blob_type("A String")).to be_nil}
     specify {expect(RJGit.repository_type("A String")).to be_nil}
@@ -360,7 +426,7 @@ describe RJGit do
     specify {expect(RJGit.underscore("CamelCaseToSnakeCase")).to eq 'camel_case_to_snake_case'}
     specify {{Constants::OBJ_BLOB => :blob, Constants::OBJ_COMMIT => :commit, Constants::OBJ_TREE => :tree, Constants::OBJ_TAG => :tag }.each {|k,v| expect(RJGit.sym_for_type(k)).to eq v}}
   end
-  
+
   after(:all) do
     @bare_repo = nil
   end

--- a/spec/rjgit_spec.rb
+++ b/spec/rjgit_spec.rb
@@ -390,7 +390,7 @@ index 45c2f8a..3291bba 100644
 --- a/org.eclipse.jgit/src/org/spearce/jgit/lib/RepositoryConfig.java
 +++ b/org.eclipse.jgit/src/org/spearce/jgit/lib/RepositoryConfig.java
 EOF
-        expect {RJGit::Plumbing::ApplyPatchToIndex.new(@repo, patch)}.to raise_error Java::OrgEclipseJgitApiErrors::PatchApplyException
+        expect {RJGit::Plumbing::ApplyPatchToIndex.new(@repo, patch)}.to raise_error RJGit::PatchApplyException
       end
 
       it 'throws a PatchApplyException when encountering a malformed hunk' do
@@ -409,7 +409,7 @@ diff --git a/lib/grit.rb b/lib/grit.rb\nindex 77aa887..6afcf64 100644\n--- a/lib
 EOF
         [patch1, patch2].each do |patch|
           applier = RJGit::Plumbing::ApplyPatchToIndex.new(@repo, patch)
-          expect {applier.build_map}.to raise_error Java::OrgEclipseJgitApiErrors::PatchApplyException
+          expect {applier.build_map}.to raise_error RJGit::PatchApplyException
         end
       end
 


### PR DESCRIPTION
This started as an experiment to see how difficult it would be to implement a version of JGit's `ApplyCommand` that applies a patch to a tree in the repository, rather than to the working directory. See [here](https://github.com/gollum/rjgit_adapter/issues/2) for a description of the functionality that is currently missing.

The new `Plumbing::ApplyPatchToIndex` class is a ruby implementation of [this JGit class](https://github.com/eclipse/jgit/blob/master/org.eclipse.jgit/src/org/eclipse/jgit/api/ApplyCommand.java#L172), or at least of its main logic:

* The `ApplyPatchToIndex#build_map` method executes the JGit `ApplyCommand.call`logic
* The `ApplyPatchToIndex#apply` method executes the JGit `ApplyCommand.apply` logic

In writing these methods I just followed the Java code step by step and attempted to translate it to some sane Ruby. It turned out the actual patch application logic was relatively simple: much of the code in the JGit class concerns initializing, copying, and looping over arrays, which we can vastly simplify thanks to JRuby. And another large part of the JGit class concerns making the changes on the file system, which we're not interested in.

I was amazed to find out that the code seems to actually *work*. :) Try running this test script:

```ruby
require './lib/rjgit.rb'
include RJGit

r = Repo.new('/path/to/repo')

patch = ''
diff  = RJGit::Porcelain.diff(r, {:patch => true, :new_rev => r.commits[1].id, :old_rev => r.commits[0].id})
diff.each {|x| patch << x[:patch]}

builder = Plumbing::ApplyPatchToIndex.new(r, patch)

builder.build_map

puts builder.treemap.inspect
```

This will produce a treemap corresponding to a revert of the last commit of your target repo. You could theoretically then commit this to the repository by calling `builder.commit`. Neat, if I do say so myself. :)

This at least gives us some basis for judging whether we want to implement this code in RJGit, or whether it is too hackish and we need to submit a patch to JGit. @bartkamphorst: I would understand if you still prefer the second option, but wanted to give this a go at least.

Note: the only logic that I haven't implemented yet, because I don't understand it well enough, is [this bit concerning newlines](https://github.com/eclipse/jgit/blob/master/org.eclipse.jgit/src/org/eclipse/jgit/api/ApplyCommand.java#L249-L252).