### PR TITLE
Implement porcelain describe

### DIFF
--- a/lib/rjgit.rb
+++ b/lib/rjgit.rb
@@ -163,6 +163,12 @@ module RJGit
       RJGit.convert_diff_entries(diff_entries)
     end
 
+    def self.describe(repository, ref, options = {})
+      options = {:always => false, :long => false, :tags => false}.merge(options)
+      repo = RJGit.repository_type(repository)
+      git = RubyGit.new(repo).jgit
+      git.describe.set_target(ref).set_always(options[:always]).set_long(options[:long]).set_tags(options[:tags]).call
+    end
   end
 
   module Plumbing

--- a/lib/rjgit.rb
+++ b/lib/rjgit.rb
@@ -164,10 +164,18 @@ module RJGit
     end
 
     def self.describe(repository, ref, options = {})
-      options = {:always => false, :long => false, :tags => false}.merge(options)
+      options = {:always => false, :long => false, :tags => false, :match => []}.merge(options)
       repo = RJGit.repository_type(repository)
       git = RubyGit.new(repo).jgit
-      git.describe.set_target(ref).set_always(options[:always]).set_long(options[:long]).set_tags(options[:tags]).call
+      command = git.describe.
+        set_target(ref).
+        set_always(options[:always]).
+        set_long(options[:long]).
+        set_tags(options[:tags])
+      command = options[:match].each_with_object(command) do |match|
+        command.set_match(match)
+      end
+      command.call
     end
   end
 

--- a/spec/rjgit_spec.rb
+++ b/spec/rjgit_spec.rb
@@ -170,9 +170,19 @@ describe RJGit do
         end
       end
 
-    it "mimics git-describe" do
-      id = Porcelain.commit(@repo, "Initial commit").id
-      expect(Porcelain.describe(@repo, id)).to match(/\Av0\.0-2-g[0-9a-f]{7}\z/)
+    describe 'git-describe' do
+      it "mimics git-describe" do
+        id = Porcelain.commit(@repo, "Initial commit").id
+        expect(Porcelain.describe(@repo, id)).to match(/\Av0\.0-2-g[0-9a-f]{7}\z/)
+      end
+
+      it "matches the right tag when match is used" do
+        @repo.git.tag('v0.1', 'Tag v0.1', Porcelain.commit(@repo, "Previous commit").id)
+        id = Porcelain.commit(@repo, "Initial commit").id
+        expect(Porcelain.describe(@repo, id, match: ['v0.0'])).to match(/\Av0\.0-4-g[0-9a-f]{7}\z/)
+        expect(Porcelain.describe(@repo, id, match: ['v0.1'])).to match(/\Av0\.1-1-g[0-9a-f]{7}\z/)
+        expect(Porcelain.describe(@repo, id, match: ['v0.0', 'v0.1'])).to match(/\Av0\.1-1-g[0-9a-f]{7}\z/)
+      end
     end
 
     after(:all) do

--- a/spec/rjgit_spec.rb
+++ b/spec/rjgit_spec.rb
@@ -182,6 +182,13 @@ describe RJGit do
         expect(Porcelain.describe(@repo, id, match: ['v0.0'])).to match(/\Av0\.0-4-g[0-9a-f]{7}\z/)
         expect(Porcelain.describe(@repo, id, match: ['v0.1'])).to match(/\Av0\.1-1-g[0-9a-f]{7}\z/)
         expect(Porcelain.describe(@repo, id, match: ['v0.0', 'v0.1'])).to match(/\Av0\.1-1-g[0-9a-f]{7}\z/)
+        expect(Porcelain.describe(@repo, id, match: ['v0.*'])).to match(/\Av0\.1-1-g[0-9a-f]{7}\z/)
+        expect(Porcelain.describe(@repo, id, match: ['v99'])).to be_nil
+        expect(Porcelain.describe(@repo, id, match: ['*[a'])).to be_nil # Swallows NoClosingBracketException, a type of InvalidPatternException
+      end
+
+      it "returns nil when the ref doesn't exist" do
+        expect(Porcelain.describe(@repo, 'abcdef123456')).to be_nil # Swallows RefNotFoundException
       end
     end
 

--- a/spec/rjgit_spec.rb
+++ b/spec/rjgit_spec.rb
@@ -170,6 +170,11 @@ describe RJGit do
         end
       end
 
+    it "mimics git-describe" do
+      id = Porcelain.commit(@repo, "Initial commit").id
+      expect(Porcelain.describe(@repo, id)).to match(/\Av0\.0-2-g[0-9a-f]{7}\z/)
+    end
+
     after(:all) do
       @repo = nil
       remove_temp_repo(@temp_repo_path)


### PR DESCRIPTION
I intend to implement `grep` as well, following https://stackoverflow.com/questions/15572483/how-to-do-git-grep-e-pattern-with-jgit/16263886#16263886.

It's going to be more work than `describe` was, so before I move forward, could a maintainer please tell me 1) whether the project would accept such an addition? and 2) whether it should be on a separate branch?

Thank you!