### PR TITLE
Improve performance of retrieving blob data

### DIFF
--- a/lib/blob.rb
+++ b/lib/blob.rb
@@ -36,7 +36,7 @@ module RJGit
     # The binary contents of this blob.
     # Returns String
     def data
-      @data ||= RJGit::Porcelain.cat_file(@jrepo, @jblob, path)
+      @data ||= RJGit::Porcelain.cat_file(@jrepo, self)
     end
     
     def is_symlink?

--- a/lib/blob.rb
+++ b/lib/blob.rb
@@ -36,7 +36,7 @@ module RJGit
     # The binary contents of this blob.
     # Returns String
     def data
-      @data ||= RJGit::Porcelain.cat_file(@jrepo, @jblob) 
+      @data ||= RJGit::Porcelain.cat_file(@jrepo, @jblob, path)
     end
     
     def is_symlink?

--- a/lib/rjgit.rb
+++ b/lib/rjgit.rb
@@ -231,8 +231,7 @@ module RJGit
         end
         bytes = repo.open(id).get_bytes
 
-        binary = RawText.is_binary(bytes)
-        next if binary
+        next if RawText.is_binary(bytes)
 
         file_contents = bytes.to_s
         next unless query.match(file_contents)

--- a/lib/rjgit.rb
+++ b/lib/rjgit.rb
@@ -62,7 +62,7 @@ module RJGit
       # Try to resolve symlinks; return nil otherwise
       mode = if path
         last_commit_hash = jrepo.resolve(Constants::HEAD)
-        return nil if last_commit_hash.nil?
+        return nil unless last_commit_hash
         jtree = RevWalk.new(jrepo).parse_commit(last_commit_hash).get_tree
         RJGit.get_file_mode_with_path(jrepo, path, jtree)
       else

--- a/lib/rjgit.rb
+++ b/lib/rjgit.rb
@@ -234,7 +234,7 @@ module RJGit
         binary = RawText.is_binary(bytes)
         next if binary
 
-        file_contents = bytes.to_a.pack('c*').force_encoding('UTF-8').encode('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '')
+        file_contents = bytes.to_s
         next unless query.match(file_contents)
 
         rows = file_contents.split("\n")

--- a/lib/rjgit.rb
+++ b/lib/rjgit.rb
@@ -56,18 +56,11 @@ module RJGit
 
     # http://dev.eclipse.org/mhonarc/lists/jgit-dev/msg00558.html
     def self.cat_file(repository, blob)
-      path = blob.path if blob.respond_to?(:path)
+      mode = blob.mode if blob.respond_to?(:mode)
       jrepo = RJGit.repository_type(repository)
       jblob = RJGit.blob_type(blob)
       # Try to resolve symlinks; return nil otherwise
-      mode = if path
-        last_commit_hash = jrepo.resolve(Constants::HEAD)
-        return nil unless last_commit_hash
-        jtree = RevWalk.new(jrepo).parse_commit(last_commit_hash).get_tree
-        RJGit.get_file_mode_with_path(jrepo, path, jtree)
-      else
-        RJGit.get_file_mode(jrepo, jblob)
-      end
+      mode ||= RJGit.get_file_mode(jrepo, jblob)
       if mode == SYMLINK_TYPE
         symlink_source = jrepo.open(jblob.id).get_bytes.to_a.pack('c*').force_encoding('UTF-8')
         blob = Blob.find_blob(jrepo, symlink_source)
@@ -221,7 +214,8 @@ module RJGit
       # To avoid missing full-line matches during the optimization, we first convert multiline anchors to single-line anchors.
       query = Regexp.new(query.source.gsub(/\A\\A/, '^').gsub(/\\z\z/, '$'), query.options)
 
-      files_to_scan = ls_tree(repo, nil, options.fetch(:ref, 'HEAD'), ls_tree_options)
+      ref = options.fetch(:ref, 'HEAD')
+      files_to_scan = ls_tree(repo, nil, ref, ls_tree_options)
 
       files_to_scan.each_with_object({}) do |file, result|
         id = if file[:mode] == SYMLINK_TYPE
@@ -231,7 +225,7 @@ module RJGit
             dir[-1] = symlink_source
             symlink_source = File.join(dir)
           end
-          Blob.find_blob(repo, symlink_source).jblob.id
+          Blob.find_blob(repo, symlink_source, ref).jblob.id
         else
           ObjectId.from_string(file[:id])
         end

--- a/lib/rjgit.rb
+++ b/lib/rjgit.rb
@@ -226,6 +226,11 @@ module RJGit
       files_to_scan.each_with_object({}) do |file, result|
         id = if file[:mode] == SYMLINK_TYPE
           symlink_source = repo.open(ObjectId.from_string(file[:id])).get_bytes.to_a.pack('c*').force_encoding('UTF-8')
+          unless symlink_source[File::SEPARATOR]
+            dir = file[:path].split(File::SEPARATOR)
+            dir[-1] = symlink_source
+            symlink_source = File.join(dir)
+          end
           Blob.find_blob(repo, symlink_source).jblob.id
         else
           ObjectId.from_string(file[:id])

--- a/lib/rjgit.rb
+++ b/lib/rjgit.rb
@@ -55,7 +55,8 @@ module RJGit
     end
 
     # http://dev.eclipse.org/mhonarc/lists/jgit-dev/msg00558.html
-    def self.cat_file(repository, blob, path = nil)
+    def self.cat_file(repository, blob)
+      path = blob.path if blob.respond_to?(:path)
       jrepo = RJGit.repository_type(repository)
       jblob = RJGit.blob_type(blob)
       # Try to resolve symlinks; return nil otherwise

--- a/spec/rjgit_spec.rb
+++ b/spec/rjgit_spec.rb
@@ -237,9 +237,7 @@ describe RJGit do
         end
 
         it 'find matching content in symlinked files' do
-          expect(Porcelain.grep(@repo, /California/, :path_filter => symlink_file_name)).to eq(
-            symlink_file_name => ["Department of English, University of California"]
-          )
+          expect(Porcelain.grep(@repo, /California/, :path_filter => symlink_file_name)).to eq(symlink_file_name => ["Department of English, University of California"])
         end
       end
 

--- a/spec/rjgit_spec.rb
+++ b/spec/rjgit_spec.rb
@@ -227,6 +227,22 @@ describe RJGit do
         expect(Porcelain.grep(@repo, /./, :path_filter => "homer-excited.png")).to eq({})
       end
 
+      context 'with a symlink' do
+        let(:symlink_file_name) { 'symlink.txt' }
+        let(:symlink_file_path) { File.join(@temp_repo_path, symlink_file_name) }
+        before do
+          File.symlink('deconstructions.txt', symlink_file_path)
+          Porcelain.add(@repo, symlink_file_name)
+          Porcelain.commit(@repo, 'Added a symlink')
+        end
+
+        it 'find matching content in symlinked files' do
+          expect(Porcelain.grep(@repo, /California/, :path_filter => symlink_file_name)).to eq(
+            symlink_file_name => ["Department of English, University of California"]
+          )
+        end
+      end
+
       it 'only greps for Regexps and Strings' do
         expect { Porcelain.grep(@repo, 10..20) }.to raise_error("A Range was passed to RJGit::Porcelain.grep().  Only Regexps and Strings are supported!")
       end


### PR DESCRIPTION
I discovered that Porcelain.grep performs horribly.  I did some profiling and identified a few issues, mostly involving unnecessarily retrieving data that we already had in memory.

I tested performance against a repo of mine and a085d06bcc5ddd6880de479250f55586cfae0935 improved runtime of a simple `Porcelain.grep` call from 6.1 seconds to 0.57 seconds.

Commit d5019e6a67453a0191408067bcb9c53436c9ee25 further improved runtime to 0.28 seconds.  (The performance bottleneck that d5019e6a67453a0191408067bcb9c53436c9ee25 bypasses is `Java::OrgEclipseJgitTreewalk::TreeWalk.forPath`.)

The last remaining bottleneck was `get_bytes.to_a`, accounting for 80% of runtime.  b3d01eca9f3b802178ba77646ed5c46e05743623 fixes this.  I ran this against a much larger repo, and b3d01eca9f3b802178ba77646ed5c46e05743623 alone cut runtime from 103 seconds to 7 seconds!