### PR TITLE
Update Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,8 @@
 source 'https://rubygems.org'
 
+gemspec
+
 gem 'mime-types', '~> 3.3.1'
-gem 'rake', '>= 12.3.3'
 
 gem 'coveralls', '~> 0.8.23', require: false
 

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'mime-types', '~> 3.3.1'
+gem 'rake', '>= 12.3.3'
 
 gem 'coveralls', '~> 0.8.23', require: false
 


### PR DESCRIPTION
Remove redundant mime-types requirement and source from .gemspec instead. (I noticed the Gemfile contained a more specific requirement for mime-types than the gemspec, causing an orange lamp on CuttingEdge.)