### PR TITLE
Refactor Tree: add efficient find methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,9 @@ tree = repo.find("959329025f67539fb82e76b02782322fad032000", :tree) #...or by SH
 tree.data # List the tree's contents (blobs and trees). Also tree.id, tree.mode, etc.
 tree.each {|entry| puts entry.inspect} # Loop over the Tree's children (Blobs and Trees)
 tree.find_blob {|entry| entry[:name] == 'foo.txt'} # Find a single blob that matches the block
-tree.find_tree {|entry| entry[:name] == 'mytree' } # Find a single tree that matches the blob
+tree.find_tree {|entry| entry[:name] == 'mytree' } # Find a single tree that matches the block
+tree.find {|entry| ...} # Find a single entry that matches the block
+tree.find_all {|entry entry[:name].include?('.') } # Find all entries matching the block
 tree.trees # An array of the Tree's child Trees
 tree.blobs # An array of the Tree's child Blobs
 Porcelain::ls_tree(repo, repo.tree("example"), :print => true, :recursive => true, :ref => 'mybranch') # Outputs the Tree's contents to $stdout. Faster for recursive listing than Tree#each. Passing nil as the second argument lists the entire repository. ref defaults to HEAD.

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ tree = repo.tree("example") # Retrieve a tree by filepath...
 tree = repo.find("959329025f67539fb82e76b02782322fad032000", :tree) #...or by SHA
 tree.data # List the tree's contents (blobs and trees). Also tree.id, tree.mode, etc.
 tree.each {|entry| puts entry.inspect} # Loop over the Tree's children (Blobs and Trees)
+tree.find_blob {|entry| entry[:name] == 'foo.txt'} # Find a single blob that matches the block
+tree.find_tree {|entry| entry[:name] == 'mytree' } # Find a single tree that matches the blob
 tree.trees # An array of the Tree's child Trees
 tree.blobs # An array of the Tree's child Blobs
 Porcelain::ls_tree(repo, repo.tree("example"), :print => true, :recursive => true, :ref => 'mybranch') # Outputs the Tree's contents to $stdout. Faster for recursive listing than Tree#each. Passing nil as the second argument lists the entire repository. ref defaults to HEAD.

--- a/lib/tree.rb
+++ b/lib/tree.rb
@@ -41,22 +41,17 @@ module RJGit
 
     def find_blob(&block)
       return nil unless block_given?
-      find(:Blob) {|tree_entry| yield tree_entry }
+      _find(:Blob) {|tree_entry| yield tree_entry }
     end
 
     def find_tree(&block)
       return nil unless block_given?
-      find(:Tree) {|tree_entry| yield tree_entry }
+      _find(:Tree) {|tree_entry| yield tree_entry }
     end
 
-    def find(type = nil, &block)
+    def find(&block)
       return nil unless block_given?
-      treewalk = init_walk
-      while treewalk.next
-        entry = tree_entry(treewalk)
-        next if type && type != entry[:type]
-        return wrap_tree_or_blob(entry[:type], entry[:mode], entry[:path], entry[:id]) if yield entry
-      end
+      _find(nil) {|tree_entry| yield tree_entry}
     end
     
     def each(&block)
@@ -122,6 +117,16 @@ module RJGit
 
     def contents_array
       @contents_ary ||= jtree_entries
+    end
+
+    def _find(type = nil, &block)
+      return nil unless block_given?
+      treewalk = init_walk
+      while treewalk.next
+        entry = tree_entry(treewalk)
+        next if type && type != entry[:type]
+        return wrap_tree_or_blob(entry[:type], entry[:mode], entry[:path], entry[:id]) if yield entry
+      end
     end
 
     def init_walk(recurse=false)

--- a/lib/tree.rb
+++ b/lib/tree.rb
@@ -25,10 +25,6 @@ module RJGit
       RJGit::Porcelain.ls_tree(@jrepo, @path, Constants::HEAD, options={:print => true, :io => strio})
       @contents = strio.string
     end
-
-    def count
-      contents_array.size
-    end
           
     def recursive_contents_array(limit = nil)
       if @recursive_contents.nil? || @recursive_contents[:limit] != limit

--- a/lib/tree.rb
+++ b/lib/tree.rb
@@ -64,7 +64,7 @@ module RJGit
     end
     
     def each(&block)
-      block_given? ? contents_array.each(&block) : contents_array.to_enum
+      contents_array.each(&block)
     end
     
     def blobs

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,11 @@ require 'rspec/collection_matchers'
 require 'rjgit'
 include RJGit
 
+java_import 'org.eclipse.jgit.util.SystemReader'
+# Make sure JGit ignores the user's git config to prevent errors:
+# For example, when the user has GPG commit signing enabled, JGit will attempt and fail to access GPG keys.
+SystemReader.getInstance().userConfig.clear()
+
 TEST_REPO_NAME = "dot_git"
 TEST_REPO_PATH = File.join(File.dirname(__FILE__), 'fixtures', TEST_REPO_NAME)
 TEST_BARE_REPO_NAME = "dot_bare_git"

--- a/spec/tree_spec.rb
+++ b/spec/tree_spec.rb
@@ -19,7 +19,7 @@ describe Tree do
     end
     
     it "has an array of contents" do
-      expect(@tree.each.to_a).to be_kind_of Array
+      expect(@tree.to_a).to be_kind_of Array
     end
     
     it "has an array of all contents (recursive)" do

--- a/spec/tree_spec.rb
+++ b/spec/tree_spec.rb
@@ -19,7 +19,7 @@ describe Tree do
     end
     
     it "has an array of contents" do
-      expect(@tree.contents_array).to be_kind_of Array
+      expect(@tree.each.to_a).to be_kind_of Array
     end
     
     it "has an array of all contents (recursive)" do
@@ -49,6 +49,37 @@ describe Tree do
     
     it "has blobs" do
       expect(@tree.blobs).to be_kind_of Array
+    end
+
+    it "finds blobs and trees efficiently" do
+      count = 0
+      result = @bare_repo.head.tree.find do |tree_entry|
+        count = count+1
+        tree_entry[:name] == '.gitignore'
+      end
+      expect(result).to be_a Blob
+      expect(result.id).to eq 'baaa47163a922b716898936f4ab032db4e08ae8a'
+      expect(count).to eq 1 # .gitignore is first in the tree, so no more than one iteration should have been performed.
+    end
+
+    it "finds a particular blobs given a block" do
+      expect(@tree.find_blob).to be_nil
+      result = @tree.find_blob {|tree_entry| tree_entry[:name] == 'grit.rb'}
+      expect(result).to be_a Blob
+      expect(result.id).to eq '77aa887449c28a922a660b2bb749e4127f7664e5'
+      # 'grit' is an existing tree, but this method should not match trees
+      no_exist =  @tree.find_blob {|tree_entry| tree_entry[:name] == 'grit'}
+      expect(no_exist).to be_nil
+    end
+
+    it "finds a particular tree given a block" do
+      expect(@tree.find_tree).to be_nil
+      result = @tree.find_tree {|tree_entry| tree_entry[:name] == 'grit'}
+      expect(result).to be_a Tree
+      expect(result.id).to eq '02776a9f673a9cd6e2dfaebdb4a20de867303091'
+      # 'grit.rb' is an existing blob, but this method should not match blobs
+      no_exist =  @tree.find_tree {|tree_entry| tree_entry[:name] == 'grit.rb'}
+      expect(no_exist).to be_nil
     end
     
     it "provides access to its children through the / method" do

--- a/spec/tree_spec.rb
+++ b/spec/tree_spec.rb
@@ -55,11 +55,11 @@ describe Tree do
       count = 0
       result = @bare_repo.head.tree.find do |tree_entry|
         count = count+1
-        tree_entry[:name] == '.gitignore'
+        tree_entry[:name] == 'Manifest.txt'
       end
       expect(result).to be_a Blob
-      expect(result.id).to eq 'baaa47163a922b716898936f4ab032db4e08ae8a'
-      expect(count).to eq 1 # .gitignore is first in the tree, so no more than one iteration should have been performed.
+      expect(result.id).to eq '22158f1075113476d332d6f5112cf948f38ae658'
+      expect(count).to eq 3 # 'Manifest.txt' is third in the tree, so no more than three iteration should have been performed
     end
 
     it "finds a particular blobs given a block" do

--- a/spec/tree_spec.rb
+++ b/spec/tree_spec.rb
@@ -62,6 +62,19 @@ describe Tree do
       expect(count).to eq 3 # 'Manifest.txt' is third in the tree, so no more than three iteration should have been performed
     end
 
+    it "finds multiple blobs and trees efficiently" do
+      count = 0
+      result = @bare_repo.head.tree.find_all do |tree_entry|
+        count = count+1
+        tree_entry[:name].include? 'i'
+      end
+      expect(result).to be_a Array
+      expect(result.count).to eq 5
+      expect(result.first).to be_a Blob
+      expect(result.last).to be_a Tree
+      expect(count).to eq 8 # Cycles through the whole tree
+    end
+
     it "finds a particular blobs given a block" do
       expect(@tree.find_blob).to be_nil
       result = @tree.find_blob {|tree_entry| tree_entry[:name] == 'grit.rb'}


### PR DESCRIPTION
While working on https://github.com/gollum/gollum-lib/pull/437 I discovered there is no efficient way to find a single blob or tree within a `Tree` in RJGit. Our current methods wrap *all* of the (java) contents of a tree as a `Blob` or a `Tree`, then we select a subset of that entire array. I have now added `#find_blob` and `#find_tree`, which iterate over the tree and return a wrapped `Blob` or `Tree` as soon as entry is found that matches the block.