### PR TITLE
Fix JRuby 10

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [jruby-9.2.18.0, jruby-head]
+        ruby: [jruby-9.4.15.0, jruby-10.1.1.0, jruby-head]
     steps:
       - run: echo "The job was automatically triggered by a ${{ github.event_name }} event."
       - run: echo "This job is now running on a ${{ runner.os }} server hosted by GitHub!"

--- a/lib/repo.rb
+++ b/lib/repo.rb
@@ -55,13 +55,13 @@ module RJGit
       # Default value for bare
       bare = false
       # If the repo path is new
-      unless File.exists?(epath) 
+      unless File.exist?(epath)
         # take user setting if defined
         bare = !! options[:is_bare] unless options[:is_bare].nil?
       # If the repo path exists
       else
         # scan the directory for a .git directory
-        bare = File.exists?(gitpath) ? false : true
+        bare = File.exist?(gitpath) ? false : true
         # but allow overriding user setting
         bare = !! options[:is_bare] unless options[:is_bare].nil? 
       end

--- a/lib/rjgit.rb
+++ b/lib/rjgit.rb
@@ -445,7 +445,7 @@ module RJGit
 
       # Take the result of RJGit::Porcelain.diff with options[:patch] = true and return a patch String
       def self.diffs_to_patch(diffs)
-        diffs.inject(""){|result, diff| result << diff[:patch]}
+        diffs.inject(+""){|result, diff| result << diff[:patch]}
       end
 
       def initialize(repository, patch, ref = Constants::HEAD)

--- a/spec/repo_spec.rb
+++ b/spec/repo_spec.rb
@@ -15,9 +15,9 @@ describe LocalRefWriter do
   it "writes to the specified file path under the repository's path" do
     filename = File.join('info','nonexistent')
     newfile = File.join(@repo.path, filename)
-    expect(File.exists?(newfile)).to be false
+    expect(File.exist?(newfile)).to be false
     @writer.writeFile(filename, "Test".to_java_bytes)
-    expect(File.exists?(newfile)).to be true
+    expect(File.exist?(newfile)).to be true
   end
 
   it "inherits the write_info_refs method from its JGit superclass" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -41,7 +41,7 @@ def create_temp_repo(clone_path, bare = false)
 end
 
 def remove_temp_repo(path)
-  if File.exists?(path)
+  if File.exist?(path)
     FileUtils.rm_rf(path)
   else
     puts "\nWARNING: could not delete path (directory #{path} does not exist). Called by #{caller[0]}.\n"

--- a/spec/support/matchers/filematchers.rb
+++ b/spec/support/matchers/filematchers.rb
@@ -8,6 +8,6 @@ end
 
 RSpec::Matchers.define :exist do 
   match do |match| 
-    File.exists?(match) 
+    File.exist?(match)
   end
 end


### PR DESCRIPTION
Corrects use of now-removed `File.exists?`, and mutating of a string literal without `+@`, which is now a warning.

Tested under JRuby 10.1.1.0.